### PR TITLE
Use TextChannel#send instead of TextChannel#sendMessage

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ bot.on('message', (message) => {
     const thisWord = 'fart';
     if (message.content.includes(thisWord)) {
         message.delete(1000);
-        message.channel.sendMessage('**@&#$%!**');
+        message.channel.send('**@&#$%!**');
         for ($i = 0; $i <= 100; $i++) {
             message.author.send('Le mot **FART** est interdit!');
         }


### PR DESCRIPTION
TextChannel#sendMessage has been deprecated for a while and should not be used anymore. You should also be getting deprecation warnings in your console because of that. 
This pull request uses TextChannel#send instead, which is the way you should send messages.